### PR TITLE
Add a GRES option, for the --gres option in SLURM

### DIFF
--- a/SLURM_OPTIONS.md
+++ b/SLURM_OPTIONS.md
@@ -129,6 +129,9 @@ This document lists all the available keys that can be used in the `slurm_option
 - **`PROPAGATE`**: Set propagation of environment variables.
   - Example: `--propagate=env_vars`
 
+- **`GRES`**: Generic Resource scheduling. Used for requesting special hardware resources.
+  - Example: `--gres=gpu:tesla:2,gpu:kepler:2,mps:400,bandwidth:lustre:no_consume:4G`
+
 ### System Options
 
 - **`REBOOT`**: Reboot the system after the job completes.

--- a/airflow_slurm/constants.py
+++ b/airflow_slurm/constants.py
@@ -80,4 +80,5 @@ SLURM_OPTS = {
     "QOS": (True, "--qos="),
     "MEM": (True, "--mem="),
     "MEM_PER_CPU": (True, "--mem-per-cpu="),
+    "GRES": (True, "--gres="),
 }


### PR DESCRIPTION
I needed this, so I added it, perhaps it might be more generally useful? See https://slurm.schedmd.com/gres.html.