### PR TITLE
19 trigger failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-slurm"
-version = "0.2.1"
+version = "0.2.2"
 description = "Airflow operator for slurm"
 readme = "README.md"
 include = ["src/airflow_slurm/py.typed"]

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -130,8 +130,6 @@ class SSHSlurmTrigger(BaseTrigger):
                     result = await conn.run(command_str, timeout=timeout)
                     return result.exit_status, result.stdout, result.stderr
 
-            except asyncssh.Error as e:
-                raise AirflowException(f"SSH connection failed: {e}")
             except asyncio.TimeoutError:
                 if attempt < max_retries - 1:
                     delay = 2 ** (attempt + 1)
@@ -148,8 +146,12 @@ class SSHSlurmTrigger(BaseTrigger):
                 else:
                     raise AirflowException(
                         f"SSH command '{command_str}' timed out after "
-                        f"{timeout} seconds ({max_retries} attempts)"
+                        f"{timeout} seconds and {max_retries} retry attempts"
                     )
+            except asyncssh.Error as e:
+                raise AirflowException(
+                    f"SSH connection failed for command '{command_str}': {e}"
+                )
 
     async def get_scontrol_output(self) -> dict | None:
         """Get SLURM job status using scontrol command.
@@ -157,9 +159,15 @@ class SSHSlurmTrigger(BaseTrigger):
         Returns:
             Dictionary containing job information or None if not found.
         """
-        exit_code, output, error = await self._execute_ssh_command(
-            ["scontrol", "--oneliner", "show", "job", self.jobid]
-        )
+        try:
+            exit_code, output, error = await self._execute_ssh_command(
+                ["scontrol", "--oneliner", "show", "job", self.jobid]
+            )
+        except AirflowException as e:
+            logger.warning(
+                "scontrol command failed: %s. Attempting sacct fallback.", e
+            )
+            exit_code, output, error = -1, "", str(e)
 
         if exit_code == 0 and len(output) > 0:
             if not output:

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -89,7 +89,7 @@ class SSHSlurmTrigger(BaseTrigger):
         )
 
     async def _execute_ssh_command(
-        self, command: list[str] | str, timeout: int = 60
+        self, command: list[str] | str, timeout: int = 10
     ) -> tuple[int, str, str]:
         """Execute command via SSH using asyncssh.
 
@@ -158,7 +158,7 @@ class SSHSlurmTrigger(BaseTrigger):
             Dictionary containing job information or None if not found.
         """
         exit_code, output, error = await self._execute_ssh_command(
-            ["scontrol", "--oneliner", "show", "job", self.jobid], timeout=30
+            ["scontrol", "--oneliner", "show", "job", self.jobid]
         )
 
         if exit_code == 0 and len(output) > 0:
@@ -193,7 +193,7 @@ class SSHSlurmTrigger(BaseTrigger):
             logger.warning("scontrol output", output)
             try:
                 exit_code, stdout, stderr = await self._execute_ssh_command(
-                    ["sacct", "--noheader", "-j", self.jobid], timeout=30
+                    ["sacct", "--noheader", "-j", self.jobid],
                 )
                 if exit_code != 0:
                     logger.warning(stderr)
@@ -267,7 +267,7 @@ class SSHSlurmTrigger(BaseTrigger):
 
         # NOTE: scancel accepts multiple job IDs as separate arguments
         exit_code, output, error = await self._execute_ssh_command(
-            ["scancel"] + list(ids), timeout=30
+            ["scancel"] + list(ids),
         )
 
         if exit_code != 0:
@@ -292,7 +292,7 @@ class SSHSlurmTrigger(BaseTrigger):
         """
         try:
             exit_code, stdout, stderr = await self._execute_ssh_command(
-                ["cat", out_file], timeout=10
+                ["cat", out_file],
             )
 
             if exit_code != 0:

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -102,9 +102,8 @@ class SSHSlurmTrigger(BaseTrigger):
         """
         ssh_args = await aget_ssh_connection_details(self.ssh_conn_id)
 
-        # Build asyncssh connection parameters
         connect_kwargs = {
-            "known_hosts": None,  # Disable host key checking for automation
+            "known_hosts": None,
         }
 
         if ssh_args.key_file:
@@ -115,27 +114,42 @@ class SSHSlurmTrigger(BaseTrigger):
                 ssh_args.server_host_key_algs
             )
 
-        try:
-            async with asyncssh.connect(
-                ssh_args.host,
-                username=ssh_args.username,
-                port=ssh_args.port,
-                **connect_kwargs,
-            ) as conn:
-                if isinstance(command, list):
-                    command_str = " ".join(command)
+        command_str = (
+            " ".join(command) if isinstance(command, list) else command
+        )
+        max_retries = 5
+
+        for attempt in range(max_retries):
+            try:
+                async with asyncssh.connect(
+                    ssh_args.host,
+                    username=ssh_args.username,
+                    port=ssh_args.port,
+                    **connect_kwargs,
+                ) as conn:
+                    result = await conn.run(command_str, timeout=timeout)
+                    return result.exit_status, result.stdout, result.stderr
+
+            except asyncssh.Error as e:
+                raise AirflowException(f"SSH connection failed: {e}")
+            except asyncio.TimeoutError:
+                if attempt < max_retries - 1:
+                    delay = 2 ** (attempt + 1)
+                    logger.warning(
+                        "SSH command '%s' timed out after %d seconds. "
+                        "Retry %d/%d in %d seconds.",
+                        command_str,
+                        timeout,
+                        attempt + 1,
+                        max_retries - 1,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
                 else:
-                    command_str = command
-
-                result = await conn.run(command_str, timeout=timeout)
-                return result.exit_status, result.stdout, result.stderr
-
-        except asyncssh.Error as e:
-            raise AirflowException(f"SSH connection failed: {e}")
-        except asyncio.TimeoutError:
-            raise AirflowException(
-                f"SSH command timed out after {timeout} seconds"
-            )
+                    raise AirflowException(
+                        f"SSH command '{command_str}' timed out after "
+                        f"{timeout} seconds ({max_retries} attempts)"
+                    )
 
     async def get_scontrol_output(self) -> dict | None:
         """Get SLURM job status using scontrol command.

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "airflow-slurm"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
# Trigger failure

close #19

## Context

```python
[2026-01-12 10:46:56] ERROR - Trigger failed:
Traceback (most recent call last):

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 130, in _execute_ssh_command
    result = await conn.run(command_str, timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/asyncssh/connection.py", line 4616, in run
    return await process.wait(check, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/asyncssh/process.py", line 1566, in wait
    raise TimeoutError(self.env, self.command, self.subsystem,

asyncssh.process.TimeoutError


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 992, in cleanup_finished_triggers
    result = details["task"].result()
             ^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 116, in greenback_shim
    return await _greenback_shim(orig_coro, next_send)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 201, in _greenback_shim
    next_yield, resume_greenlet = resume_greenlet.switch(next_send)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 81, in trampoline
    next_yield: Any = next_send.send(orig_coro)  # type: ignore
                      ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/outcome/_impl.py", line 185, in send
    return gen.send(self.value)
           ^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 1106, in run_trigger
    async for event in trigger.run():

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 326, in run
    slurm_job = await self.get_scontrol_output()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 146, in get_scontrol_output
    exit_code, output, error = await self._execute_ssh_command(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 134, in _execute_ssh_command
    raise AirflowException(f"SSH connection failed: {e}")

airflow.exceptions.AirflowException: SSH connection failed:
 source=airflow.task.operators.airflow_slurm.ssh_slurm_operator.SSHSlurmOperator loc=operator.py:1626
[2026-01-12 10:46:56] ERROR - Task failed with exception source=task loc=task_runner.py:972
TaskDeferralError: Trigger failure

File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 920 in run

File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1307 in _execute_task

File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 1629 in resume_execution
```

### Additional context

The root cause is a timeout when executing an SSH command
(`asyncssh.process.TimeoutError` at line 10). The exception handler in
`_execute_ssh_command` (line 134) catches this timeout and re-raises it as
"SSH connection failed", which is misleading since the connection itself may
be functional but the command execution exceeded the timeout limit.

The error propagates through the trigger mechanism causing a
`TaskDeferralError`. The issue is twofold:

1. The error message misrepresents the actual problem (timeout vs connection
   failure)
2. The timeout handling may need to be more robust or the timeout value may
   need adjustment

## Plan

### Step 1: Implement retry mechanism in `_execute_ssh_command`

- [x] Add retry logic with exponential backoff (base 2, 5 retries max)
- [x] Only retry on `asyncio.TimeoutError`, fail fast on genuine SSH errors
- [x] Add logging for each retry attempt
- [x] Calculate delay as: 2^attempt seconds (2s, 4s, 8s, 16s, 32s)

### Step 2: Update timeout values

- [x] Change default timeout in `_execute_ssh_command` from 60s to 10s
- [x] Use default timeout throughout

### Step 3: Improve error handling and messages

- [x] Update exception in `_execute_ssh_command` to distinguish between
  timeout and connection failure
- [x] Include command being executed and number of retries attempted in error
  messages
- [x] Ensure timeout exception from `_execute_ssh_command` is caught in
  `get_scontrol_output` to trigger `sacct` fallback

## Implementation log

### Step 1: Implement retry mechanism in `_execute_ssh_command`

Connection details fetching and SSH connection parameters setup were kept
outside the retry loop since they remain constant throughout the application
lifecycle. Only the connection establishment and command execution are
retried.

### Step 2: Update timeout values

Reduced default timeout to 10s and removed custom timeouts throughout. The
shorter timeout combined with the exponential backoff (2s, 4s, 8s, 16s, 32s)
provides quicker recovery whilst still allowing total wait time of up to 72s
across all retry attempts for genuinely slow operations.

### Step 3: Improve error handling and messages

Reordered exception handlers in `_execute_ssh_command` to catch
`asyncio.TimeoutError` before the broader `asyncssh.Error`, ensuring timeouts
are properly distinguished from genuine SSH connection failures. Updated error
messages to include the command being executed and number of retry attempts.
Added exception handling in `get_scontrol_output` to catch `AirflowException`
and trigger the sacct fallback, preventing timeout errors from propagating as
unhandled `TaskDeferralError`.