### PR TITLE
21 trigger failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "pre-commit>=3.8.0",
     "pytest>=8.3.2",
     "coverage>=7.6.1",
+    "ty>=0.0.1a22",
 ]
 typing = [
     "ty>=0.0.1a8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-slurm"
-version = "0.2.2"
+version = "0.2.3"
 description = "Airflow operator for slurm"
 readme = "README.md"
 include = ["src/airflow_slurm/py.typed"]

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -179,18 +179,20 @@ class SSHSlurmTrigger(BaseTrigger):
              (allows up to 3 attempts tracked by self.scontrol_try)
            - If fails or returns non-zero exit code: proceed to fallback
 
-        2. Fallback method: Execute `sacct --noheader -j <jobid>`
-           - Used when job has left the active queue (completed/failed)
-           - Checks if all output lines contain "COMPLETED"
-           - If sacct fails: assume job is completed
-           - If sacct succeeds but not all lines are COMPLETED: raise error
+        2. Fallback method: Execute `sacct -P --format=JobID,State,ExitCode
+           --noheader -j <jobid>`
+           - Used when job has left the active queue
+           - Parses pipe-delimited output to extract main job state
+           - Checks if main job is in a terminal state
+           - Returns the actual state (COMPLETED, FAILED, etc.)
 
         Returns:
             Dictionary containing job information or None if scontrol
             returned empty output (caller should retry).
 
         Raises:
-            RuntimeError: When sacct shows job is not fully completed.
+            RuntimeError: When job state cannot be determined or is
+                non-terminal.
             AirflowException: When scontrol fails after 3 empty responses.
         """
         try:
@@ -233,30 +235,59 @@ class SSHSlurmTrigger(BaseTrigger):
                 "scontrol returned %s with error %s.", exit_code, error
             )
             logger.warning("scontrol output", output)
-            try:
-                exit_code, stdout, stderr = await self._execute_ssh_command(
-                    ["sacct", "--noheader", "-j", self.jobid],
-                )
-                if exit_code != 0:
-                    logger.warning(stderr)
-                    raise RuntimeError(
-                        "sacct returned %s: %s", exit_code, stderr
-                    )
-                output = stdout.strip().splitlines()
-                is_completed = all("COMPLETED" in line for line in output)
-            except RuntimeError:
-                logger.warning(
-                    "Could not infer job state from running "
-                    "scontrol and sacct. Assuming completed."
-                )
-                is_completed = True
-            out = dict(**self.last_full_state)
-            if is_completed:
-                out["state"] = "COMPLETED"
-            else:
+
+            exit_code, stdout, stderr = await self._execute_ssh_command(
+                [
+                    "sacct",
+                    "-P",
+                    "--format=JobID,State,ExitCode",
+                    "--noheader",
+                    "-j",
+                    self.jobid,
+                ],
+            )
+
+            if exit_code != 0:
+                logger.warning("sacct returned %s: %s", exit_code, stderr)
                 raise RuntimeError(
                     f"Could not determine state of job {self.jobid}"
                 )
+
+            lines = stdout.strip().splitlines()
+            if not lines:
+                raise RuntimeError(
+                    f"Could not determine state of job {self.jobid}"
+                )
+
+            main_job_state = None
+            main_job_exit_code = None
+            for line in lines:
+                job_id, state, exit_code_str = line.split("|")
+
+                if job_id == self.jobid:
+                    main_job_state = state
+                    main_job_exit_code = exit_code_str
+                    break
+
+            if main_job_state is None:
+                raise RuntimeError(
+                    f"Could not determine state of job {self.jobid}"
+                )
+
+            if main_job_state not in TERMINAL_STATES:
+                raise RuntimeError(
+                    f"Could not determine state of job {self.jobid}"
+                )
+
+            if main_job_exit_code and main_job_exit_code != "0:0":
+                logger.warning(
+                    "Job %s has non-zero exit code: %s",
+                    self.jobid,
+                    main_job_exit_code,
+                )
+
+            out = dict(**self.last_full_state)
+            out["state"] = main_job_state
             return out
 
     async def parse_scontrol(

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -27,6 +27,11 @@ from .ssh_utils import aget_ssh_connection_details
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+
+class JobStateUnavailable(Exception):
+    """Raised when job state cannot be determined and retry is needed."""
+
+
 TERMINAL_STATES = {
     "COMPLETED",
     "FAILED",
@@ -168,7 +173,7 @@ class SSHSlurmTrigger(BaseTrigger):
                     f"SSH connection failed for command '{command_str}': {e}"
                 )
 
-    async def get_scontrol_output(self) -> dict | None:
+    async def _get_job_status(self) -> dict | None:
         """Get SLURM job status using scontrol with sacct fallback.
 
         Attempts to retrieve job status following this flow:
@@ -249,14 +254,17 @@ class SSHSlurmTrigger(BaseTrigger):
 
             if exit_code != 0:
                 logger.warning("sacct returned %s: %s", exit_code, stderr)
-                raise RuntimeError(
-                    f"Could not determine state of job {self.jobid}"
+                raise JobStateUnavailable(
+                    f"sacct command failed for job {self.jobid}"
                 )
 
             lines = stdout.strip().splitlines()
             if not lines:
-                raise RuntimeError(
-                    f"Could not determine state of job {self.jobid}"
+                logger.warning(
+                    "sacct returned empty output for job %s", self.jobid
+                )
+                raise JobStateUnavailable(
+                    f"sacct returned empty output for job {self.jobid}"
                 )
 
             main_job_state = None
@@ -270,13 +278,23 @@ class SSHSlurmTrigger(BaseTrigger):
                     break
 
             if main_job_state is None:
-                raise RuntimeError(
-                    f"Could not determine state of job {self.jobid}"
+                logger.warning(
+                    "Main job entry not found in sacct output for job %s",
+                    self.jobid,
+                )
+                raise JobStateUnavailable(
+                    f"Main job entry not found for job {self.jobid}"
                 )
 
             if main_job_state not in TERMINAL_STATES:
-                raise RuntimeError(
-                    f"Could not determine state of job {self.jobid}"
+                logger.warning(
+                    "Job %s is in non-terminal state %s",
+                    self.jobid,
+                    main_job_state,
+                )
+                raise JobStateUnavailable(
+                    f"Job {self.jobid} is in non-terminal state "
+                    f"{main_job_state}"
                 )
 
             if main_job_exit_code and main_job_exit_code != "0:0":
@@ -399,6 +417,53 @@ class SSHSlurmTrigger(BaseTrigger):
 
         return to_return
 
+    async def get_job_status(
+        self, max_retries: int = 3, delay_base_s: int = 3
+    ) -> dict | None:
+        """Get SLURM job status with retry logic for race conditions.
+
+        Wraps _get_job_status() with exponential backoff retry logic to
+        handle race conditions when job state is temporarily unavailable.
+        Retries occur when the sacct command fails, returns empty output,
+        the main job entry is not found, or the job is in a non-terminal
+        state.
+
+        Args:
+            max_retries: Maximum number of retry attempts.
+            delay_base_s: Base for exponential backoff delay calculation
+                (delay = base ** (attempt + 1)).
+
+        Returns:
+            Dictionary containing job information or None if scontrol
+            returned empty output.
+
+        Raises:
+            RuntimeError: When job state cannot be determined after all
+                retries are exhausted.
+        """
+        for attempt in range(max_retries):
+            try:
+                slurm_job = await self._get_job_status()
+                return slurm_job
+            except JobStateUnavailable as e:
+                if attempt < max_retries - 1:
+                    delay = delay_base_s ** (attempt + 1)
+                    logger.warning(
+                        "Job state unavailable for job %s: %s. "
+                        "Retry %d/%d in %d seconds.",
+                        self.jobid,
+                        e,
+                        attempt + 1,
+                        max_retries - 1,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    raise RuntimeError(
+                        f"Could not determine state of job {self.jobid} "
+                        f"after {max_retries} attempts"
+                    )
+
     async def run(self):
         """The function that runs when we do a defer of the SlurmOperator."""
         # How many attempts do we have to read the job information and the log?
@@ -409,8 +474,7 @@ class SSHSlurmTrigger(BaseTrigger):
 
         while True:
             await asyncio.sleep(self.tdelta_between_pokes)
-
-            slurm_job = await self.get_scontrol_output()
+            slurm_job = await self.get_job_status()
             slurm_log = await self.get_log(slurm_job.get("log_out", None))
 
             self.log.debug(f"{slurm_job=} \n {slurm_log=}")

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -27,6 +27,21 @@ from .ssh_utils import aget_ssh_connection_details
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+TERMINAL_STATES = {
+    "COMPLETED",
+    "FAILED",
+    "CANCELLED",
+    "TIMEOUT",
+    "NODE_FAIL",
+    "PREEMPTED",
+    "OUT_OF_MEMORY",
+    "BOOT_FAIL",
+    "DEADLINE",
+    "REVOKED",
+    "SUSPENDED",
+    "SPECIAL_EXIT",
+}
+
 
 def parse_scontrol_record(line):
     out = {}
@@ -154,10 +169,29 @@ class SSHSlurmTrigger(BaseTrigger):
                 )
 
     async def get_scontrol_output(self) -> dict | None:
-        """Get SLURM job status using scontrol command.
+        """Get SLURM job status using scontrol with sacct fallback.
+
+        Attempts to retrieve job status following this flow:
+
+        1. Primary method: Execute `scontrol show job <jobid>`
+           - If successful with output: parse and return job state
+           - If successful but empty output: return None to retry later
+             (allows up to 3 attempts tracked by self.scontrol_try)
+           - If fails or returns non-zero exit code: proceed to fallback
+
+        2. Fallback method: Execute `sacct --noheader -j <jobid>`
+           - Used when job has left the active queue (completed/failed)
+           - Checks if all output lines contain "COMPLETED"
+           - If sacct fails: assume job is completed
+           - If sacct succeeds but not all lines are COMPLETED: raise error
 
         Returns:
-            Dictionary containing job information or None if not found.
+            Dictionary containing job information or None if scontrol
+            returned empty output (caller should retry).
+
+        Raises:
+            RuntimeError: When sacct shows job is not fully completed.
+            AirflowException: When scontrol fails after 3 empty responses.
         """
         try:
             exit_code, output, error = await self._execute_ssh_command(

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -304,9 +304,24 @@ class SSHSlurmTrigger(BaseTrigger):
                     main_job_exit_code,
                 )
 
-            out = dict(**self.last_full_state)
-            out["state"] = main_job_state
-            return out
+            return {
+                "job_id": self.last_full_state.get(
+                    "JobId", self.last_full_state.get("job_id", self.jobid)
+                ),
+                "job_name": self.last_full_state.get(
+                    "JobName", self.last_full_state.get("job_name", "unknown")
+                ),
+                "state": main_job_state,
+                "reason": self.last_full_state.get(
+                    "Reason", self.last_full_state.get("reason", "unknown")
+                ),
+                "log_out": self.last_full_state.get(
+                    "StdOut", self.last_full_state.get("log_out", "/dev/null")
+                ),
+                "log_err": self.last_full_state.get(
+                    "StdErr", self.last_full_state.get("log_err", "/dev/null")
+                ),
+            }
 
     async def parse_scontrol(
         self, scontrol_output: Iterable[str], cancel_pending: bool = True

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "airflow-slurm"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,7 @@ dev = [
     { name = "deptry" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ty" },
 ]
 typing = [
     { name = "ty" },
@@ -64,6 +65,7 @@ dev = [
     { name = "deptry", specifier = ">=0.23.1" },
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "pytest", specifier = ">=8.3.2" },
+    { name = "ty", specifier = ">=0.0.1a22" },
 ]
 typing = [{ name = "ty", specifier = ">=0.0.1a8" }]
 


### PR DESCRIPTION
# trigger failure

close #21

## Context

The trigger fails with `RuntimeError: Could not determine state of job
32718435` when calling `get_scontrol_output()`. The error occurs during
`run()` execution in the SSH Slurm trigger.

Error traceback:
```python
[2026-01-22 20:17:39] ERROR - Trigger failed:
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 1005, in cleanup_finished_triggers
    result = details["task"].result()
  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 119, in greenback_shim
    return await _greenback_shim(orig_coro, next_send)
  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 208, in _greenback_shim
    next_yield, resume_greenlet = resume_greenlet.switch(next_send)
  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 84, in trampoline
    next_yield: Any = next_send.send(orig_coro)
  File "/home/airflow/.local/lib/python3.12/site-packages/outcome/_impl.py", line 185, in send
    return gen.send(self.value)
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 1119, in run_trigger
    async for event in trigger.run():
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 348, in run
    slurm_job = await self.get_scontrol_output()
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 223, in get_scontrol_output
    raise RuntimeError(
RuntimeError: Could not determine state of job 32718435
```

The job can still be queried with `sacct -j`.

```bash
$ sacct -j 32718435
JobID           JobName  Partition    Account  AllocCPUS      State ExitCode
------------ ---------- ---------- ---------- ---------- ---------- --------
32718435     MITgcm+BF+ dcgp_usr_+   pnrr_mer        827  COMPLETED      0:0
32718435.ba+      batch              pnrr_mer        112  COMPLETED      0:0
32718435.ex+     extern              pnrr_mer        827  COMPLETED      0:0
32718435.0   hydra_bst+              pnrr_mer        827  COMPLETED      0:0
```

### Additional context

The issue occurs in `get_scontrol_output()` (line 223-224) when the sacct
fallback logic determines the job is not completed. The current
implementation:

1. First attempts `scontrol show job` (line 164)
2. Falls back to `sacct --noheader -j <jobid>` if scontrol fails (line 203)
3. Checks if ALL output lines contain "COMPLETED" (line 212)
4. Raises RuntimeError if not all lines are COMPLETED (line 223-224)

The fallback logic is overly simplistic and fails when:
- Jobs have terminal states other than COMPLETED (FAILED, CANCELLED, TIMEOUT,
  NODE_FAIL, PREEMPTED, OUT_OF_MEMORY, etc.)
- Job arrays produce multiple lines (batch, extern, steps) with varying
  states
- sacct output needs proper column parsing

The sacct output format includes columns: JobID, JobName, Partition,
Account, AllocCPUS, State, ExitCode. The current check simply searches for
the substring "COMPLETED" in each line rather than parsing the State column.

Race condition: The error likely occurs during the transition period when
scontrol no longer knows about the job but sacct hasn't fully updated all
records yet. Job arrays have multiple entries (batch, extern, steps) that may
update asynchronously. A retry mechanism in the sacct fallback could handle
this by allowing time for all records to reach a consistent terminal state.

## Plan

### Step 1: Implement proper sacct output parsing

- [x] Change sacct command to use pipe-delimited format
  - Use `sacct -P --format=JobID,State,ExitCode --noheader -j <jobid>`
  - This gives predictable output: `JobID|State|ExitCode`
  - Eliminates whitespace parsing ambiguities and truncated field issues
- [x] Parse pipe-delimited output to extract JobID, State, and ExitCode
- [x] Extract main job entry (JobID matching exactly, without `.batch` etc.)
- [x] Define terminal states set: COMPLETED, FAILED, CANCELLED, TIMEOUT,
  NODE_FAIL, PREEMPTED, OUT_OF_MEMORY, BOOT_FAIL, DEADLINE, REVOKED,
  SUSPENDED, SPECIAL_EXIT

### Step 2: Implement state determination logic

- [x] Check if main job entry exists in sacct output
- [x] Check if main job state is terminal
  - If non-terminal state (PENDING, RUNNING, etc.) → retry needed
- [x] Return main job's state as-is when terminal
- [x] Log ExitCode if non-zero for monitoring (but don't remap COMPLETED to
  FAILED)

### Step 3: Add retry logic for race conditions

- [x] Add retry loop around sacct execution
- [x] Retry when:
  - sacct command fails (non-zero exit code)
  - Output is empty
  - Main job entry not found in sacct output
  - Main job is in non-terminal state
- [x] Do NOT retry when main job is in terminal state
- [x] Use 3 attempts with exponential backoff base 3 (3, 9, 27 seconds)
- [x] Log retry attempts with warnings
- [x] Raise RuntimeError if state cannot be determined after all retries

### Step 4: Update returned state dictionary

- [x] Return main job's state in the returned dictionary
- [x] Ensure returned dictionary matches expected format with state field
- [x] Maintain compatibility with existing trigger contract

## Implementation log

### Step 1: Implement proper sacct output parsing

Changed sacct to use pipe-delimited format (`-P --format=JobID,State,ExitCode`)
to eliminate whitespace parsing issues. Parser extracts main job entry via
exact JobID match, excluding sub-entries (.batch, .extern, etc.). Terminal
states defined as module constant. Non-zero exit codes logged but state
respected as-is.

### Step 2: Implement state determination logic

Introduced `JobStateUnavailable` exception to explicitly signal retry
conditions. The sacct fallback now raises this exception instead of
`RuntimeError` when: sacct command fails, output is empty, main job not found,
or job is in non-terminal state. This separates transient failures (requiring
retry) from permanent failures (requiring RuntimeError after retry exhaustion).

### Step 3: Add retry logic for race conditions

Extracted retry logic into public `get_job_status()` wrapper method with
exponential backoff (base 3: 3, 9, 27 seconds). The original implementation
moved to private `_get_job_status()` method. Retry occurs on
`JobStateUnavailable` exception for up to 3 attempts. After exhausting
retries, raises `RuntimeError` with descriptive message. Functions refactored
from `get_scontrol_output()`/`_get_scontrol_output()` to
`get_job_status()`/`_get_job_status()` to better reflect purpose (method uses
both scontrol and sacct).

### Step 4: Update returned state dictionary

Fixed sacct fallback return format to match scontrol path contract. Returns
dictionary with lowercase keys (job_id, job_name, state, reason, log_out,
log_err), extracting values from `last_full_state` with fallbacks for both
PascalCase (from scontrol) and lowercase keys (from initialisation). Main job
state from sacct now correctly populates the `state` field.