### PR TITLE
23 make polling job status more robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-slurm"
-version = "0.2.3"
+version = "0.2.4"
 description = "Airflow operator for slurm"
 readme = "README.md"
 include = ["src/airflow_slurm/py.typed"]

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -268,74 +268,58 @@ class SSHSlurmTrigger(BaseTrigger):
         else:
             return parsed
 
-    async def _get_job_status(self) -> JobState | None:
-        """Get SLURM job status using scontrol with sacct fallback.
-
-        Attempts to retrieve job status following this flow:
-
-        1. Primary method: Execute `scontrol show job <jobid>`
-           - If successful with output: parse and return job state
-           - If successful but empty output: return None to retry later
-             (allows up to 3 attempts tracked by self.scontrol_try)
-           - If fails or returns non-zero exit code: proceed to fallback
-
-        2. Fallback method: Execute `sacct -P --format=JobID,State,ExitCode
-           --noheader -j <jobid>`
-           - Used when job has left the active queue
-           - Parses pipe-delimited output to extract main job state
-           - Checks if main job is in a terminal state
-           - Returns the actual state (COMPLETED, FAILED, etc.)
+    async def _try_scontrol(self) -> JobState | None:
+        """Try to get job status from scontrol.
 
         Returns:
-            JobState instance containing job information or None if
-            scontrol returned empty output (caller should retry).
-
-        Raises:
-            RuntimeError: When job state cannot be determined or is
-                non-terminal.
-            AirflowException: When scontrol fails after 3 empty responses.
+            JobState with full metadata if successful, or None if job is not
+            in active queue.
         """
         try:
             exit_code, output, error = await self._execute_ssh_command(
                 ["scontrol", "--oneliner", "show", "job", self.jobid]
             )
         except AirflowException as e:
-            logger.warning(
-                "scontrol command failed: %s. Attempting sacct fallback.", e
-            )
-            exit_code, output, error = -1, "", str(e)
+            logger.warning("scontrol command failed: %s", e)
+            return None
 
-        if exit_code == 0 and len(output) > 0:
-            if not output:
+        if exit_code != 0 or not output:
+            if exit_code == 0 and not output:
                 if self.scontrol_try > 2:
                     raise AirflowException(
                         "scontrol didn't return any job information"
                     )
                 else:
                     self.scontrol_try += 1
-                    return
-
-            array_status, records = await self.parse_scontrol(
-                output.splitlines()
-            )
-
-            out = records[self.jobid.strip()]
-            self.last_full_state = JobState(
-                job_id=out["JobId"],
-                job_name=out["JobName"],
-                state=array_status,
-                reason=out["Reason"],
-                log_out=out["StdOut"],
-                log_err=out["StdErr"],
-                _is_default=False,
-            )
-            return self.last_full_state
-        else:
+                    return None
             logger.warning(
-                "scontrol returned %s with error %s.", exit_code, error
+                "scontrol returned %s with error %s", exit_code, error
             )
-            logger.warning("scontrol output", output)
+            return None
 
+        array_status, records = await self.parse_scontrol(output.splitlines())
+        out = records[self.jobid.strip()]
+        self.last_full_state = JobState(
+            job_id=out["JobId"],
+            job_name=out["JobName"],
+            state=array_status,
+            reason=out["Reason"],
+            log_out=out["StdOut"],
+            log_err=out["StdErr"],
+            _is_default=False,
+        )
+        return self.last_full_state
+
+    async def _try_sacct(self) -> JobState | None:
+        """Try to get job status from sacct.
+
+        Returns:
+            JobState with updated state if successful.
+
+        Raises:
+            JobStateUnavailable: When sacct fails or returns invalid data.
+        """
+        try:
             exit_code, stdout, stderr = await self._execute_ssh_command(
                 [
                     "sacct",
@@ -346,60 +330,109 @@ class SSHSlurmTrigger(BaseTrigger):
                     self.jobid,
                 ],
             )
+        except AirflowException as e:
+            logger.warning("sacct command failed: %s", e)
+            raise JobStateUnavailable(
+                f"sacct command failed for job {self.jobid}"
+            ) from e
 
-            if exit_code != 0:
-                logger.warning("sacct returned %s: %s", exit_code, stderr)
-                raise JobStateUnavailable(
-                    f"sacct command failed for job {self.jobid}"
-                )
+        if exit_code != 0:
+            logger.warning("sacct returned %s: %s", exit_code, stderr)
+            raise JobStateUnavailable(
+                f"sacct command failed for job {self.jobid}"
+            )
 
-            lines = stdout.strip().splitlines()
-            if not lines:
-                logger.warning(
-                    "sacct returned empty output for job %s", self.jobid
-                )
-                raise JobStateUnavailable(
-                    f"sacct returned empty output for job {self.jobid}"
-                )
+        lines = stdout.strip().splitlines()
+        if not lines:
+            logger.warning(
+                "sacct returned empty output for job %s", self.jobid
+            )
+            raise JobStateUnavailable(
+                f"sacct returned empty output for job {self.jobid}"
+            )
 
-            main_job_state = None
-            main_job_exit_code = None
-            for line in lines:
-                job_id, state, exit_code_str = line.split("|")
+        main_job_state = None
+        main_job_exit_code = None
+        for line in lines:
+            job_id, state, exit_code_str = line.split("|")
 
-                if job_id == self.jobid:
-                    main_job_state = state
-                    main_job_exit_code = exit_code_str
-                    break
+            if job_id == self.jobid:
+                main_job_state = state
+                main_job_exit_code = exit_code_str
+                break
 
-            if main_job_state is None:
-                logger.warning(
-                    "Main job entry not found in sacct output for job %s",
-                    self.jobid,
-                )
-                raise JobStateUnavailable(
-                    f"Main job entry not found for job {self.jobid}"
-                )
+        if main_job_state is None:
+            logger.warning(
+                "Main job entry not found in sacct output for job %s",
+                self.jobid,
+            )
+            raise JobStateUnavailable(
+                f"Main job entry not found for job {self.jobid}"
+            )
 
-            if main_job_state not in TERMINAL_STATES:
-                logger.warning(
-                    "Job %s is in non-terminal state %s",
-                    self.jobid,
-                    main_job_state,
-                )
-                raise JobStateUnavailable(
-                    f"Job {self.jobid} is in non-terminal state "
-                    f"{main_job_state}"
-                )
+        if main_job_state not in TERMINAL_STATES:
+            logger.warning(
+                "Job %s is in non-terminal state %s",
+                self.jobid,
+                main_job_state,
+            )
+            raise JobStateUnavailable(
+                f"Job {self.jobid} is in non-terminal state {main_job_state}"
+            )
 
-            if main_job_exit_code and main_job_exit_code != "0:0":
-                logger.warning(
-                    "Job %s has non-zero exit code: %s",
-                    self.jobid,
-                    main_job_exit_code,
-                )
+        if main_job_exit_code and main_job_exit_code != "0:0":
+            logger.warning(
+                "Job %s has non-zero exit code: %s",
+                self.jobid,
+                main_job_exit_code,
+            )
 
-            return replace(self.last_full_state, state=main_job_state)
+        return replace(self.last_full_state, state=main_job_state)
+
+    async def _get_job_status(self) -> JobState | None:
+        """Get SLURM job status with adaptive fallback sequence.
+
+        Uses an adaptive fallback sequence based on metadata availability:
+        - When full metadata is available (_is_default=False): tries squeue,
+          then scontrol, then sacct
+        - When metadata is unavailable (_is_default=True): tries scontrol,
+          then squeue, then sacct
+
+        This ensures full metadata is obtained on cold start whilst
+        optimising for reliability during the polling phase.
+
+        Returns:
+            JobState instance containing job information or None if
+            scontrol returned empty output (caller should retry).
+
+        Raises:
+            JobStateUnavailable: When all methods fail to retrieve status.
+        """
+        has_metadata = (
+            self.last_full_state is not None
+            and not self.last_full_state._is_default
+        )
+
+        if has_metadata:
+            result = await self._try_squeue()
+            if result is not None:
+                return result
+
+            result = await self._try_scontrol()
+            if result is not None:
+                return result
+
+            return await self._try_sacct()
+        else:
+            result = await self._try_scontrol()
+            if result is not None:
+                return result
+
+            result = await self._try_squeue()
+            if result is not None:
+                return result
+
+            return await self._try_sacct()
 
     async def parse_scontrol(
         self, scontrol_output: Iterable[str], cancel_pending: bool = True

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -35,14 +35,20 @@ class JobStateUnavailable(Exception):
 
 @dataclass
 class JobState:
-    """Represents the state of a SLURM job."""
+    """Represents the state of a SLURM job.
 
-    job_id: str
-    job_name: str
-    state: str
-    reason: str
-    log_out: str
-    log_err: str
+    The _is_default attribute tracks whether full metadata has been obtained
+    from scontrol. When True, only partial metadata is available (e.g., from
+    squeue), and the trigger should prefer sources that provide full metadata.
+    """
+
+    job_id: str = "unknown"
+    job_name: str = "unknown"
+    state: str = "unknown"
+    reason: str = "unknown"
+    log_out: str = "/dev/null"
+    log_err: str = "/dev/null"
+    _is_default: bool = True
 
     def dict(self) -> dict[str, str]:
         """Return serialisation-friendly dictionary representation."""
@@ -197,6 +203,71 @@ class SSHSlurmTrigger(BaseTrigger):
                     f"SSH connection failed for command '{command_str}': {e}"
                 )
 
+    def _parse_squeue_output(self, output: str) -> JobState | None:
+        """Parse squeue output and return minimal JobState.
+
+        Args:
+            output: Output from `squeue -j <jobid> -o "%i|%T"` which
+                produces pipe-delimited format: JobID|State
+
+        Returns:
+            JobState with only job_id and state populated, or None if
+            output is empty or unparseable.
+        """
+        output = output.strip()
+        if not output:
+            return None
+
+        try:
+            job_id, state = output.split("|")
+            return JobState(
+                job_id=job_id.strip(),
+                state=state.strip(),
+                _is_default=True,
+            )
+        except ValueError:
+            logger.warning("Failed to parse squeue output: %s", output)
+            return None
+
+    async def _try_squeue(self) -> JobState | None:
+        """Try to get job state from squeue, merging with cached metadata.
+
+        Executes `squeue -j <jobid> -o "%i|%T"` and merges the result with
+        cached metadata from `last_full_state`. This is useful for checking
+        job state when the SLURM database is unavailable but the scheduler
+        is still responsive.
+
+        Returns:
+            JobState with updated state merged with cached metadata, or None
+            if squeue fails or returns no data.
+        """
+        try:
+            exit_code, stdout, stderr = await self._execute_ssh_command(
+                ["squeue", "-j", self.jobid, "-o", "%i|%T"],
+                timeout=5,
+            )
+        except AirflowException as e:
+            logger.warning("squeue command failed: %s", e)
+            return None
+
+        if exit_code != 0:
+            logger.warning(
+                "squeue returned exit code %s: %s", exit_code, stderr
+            )
+            return None
+
+        parsed = self._parse_squeue_output(stdout)
+        if parsed is None:
+            return None
+
+        if self.last_full_state is not None:
+            return replace(
+                self.last_full_state,
+                state=parsed.state,
+            )
+        else:
+            return parsed
+
     async def _get_job_status(self) -> JobState | None:
         """Get SLURM job status using scontrol with sacct fallback.
 
@@ -256,6 +327,7 @@ class SSHSlurmTrigger(BaseTrigger):
                 reason=out["Reason"],
                 log_out=out["StdOut"],
                 log_err=out["StdErr"],
+                _is_default=False,
             )
             return self.last_full_state
         else:

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -37,9 +37,9 @@ class JobStateUnavailable(Exception):
 class JobState:
     """Represents the state of a SLURM job.
 
-    The _is_default attribute tracks whether full metadata has been obtained
-    from scontrol. When True, only partial metadata is available (e.g., from
-    squeue), and the trigger should prefer sources that provide full metadata.
+    The _has_full_metadata attribute tracks whether full metadata has been
+    obtained from scontrol. When True, all job details are available. When
+    False, only partial metadata is available (e.g., from squeue).
     """
 
     job_id: str = "unknown"
@@ -48,7 +48,7 @@ class JobState:
     reason: str = "unknown"
     log_out: str = "/dev/null"
     log_err: str = "/dev/null"
-    _is_default: bool = True
+    _has_full_metadata: bool = False
 
     def dict(self) -> dict[str, str]:
         """Return serialisation-friendly dictionary representation."""
@@ -223,7 +223,7 @@ class SSHSlurmTrigger(BaseTrigger):
             return JobState(
                 job_id=job_id.strip(),
                 state=state.strip(),
-                _is_default=True,
+                _has_full_metadata=False,
             )
         except ValueError:
             logger.warning("Failed to parse squeue output: %s", output)
@@ -244,7 +244,6 @@ class SSHSlurmTrigger(BaseTrigger):
         try:
             exit_code, stdout, stderr = await self._execute_ssh_command(
                 ["squeue", "-j", self.jobid, "-o", "%i|%T"],
-                timeout=5,
             )
         except AirflowException as e:
             logger.warning("squeue command failed: %s", e)
@@ -306,7 +305,7 @@ class SSHSlurmTrigger(BaseTrigger):
             reason=out["Reason"],
             log_out=out["StdOut"],
             log_err=out["StdErr"],
-            _is_default=False,
+            _has_full_metadata=True,
         )
         return self.last_full_state
 
@@ -339,7 +338,7 @@ class SSHSlurmTrigger(BaseTrigger):
         if exit_code != 0:
             logger.warning("sacct returned %s: %s", exit_code, stderr)
             raise JobStateUnavailable(
-                f"sacct command failed for job {self.jobid}"
+                f"sacct command failed for job {self.jobid}: {stderr}"
             )
 
         lines = stdout.strip().splitlines()
@@ -393,10 +392,10 @@ class SSHSlurmTrigger(BaseTrigger):
         """Get SLURM job status with adaptive fallback sequence.
 
         Uses an adaptive fallback sequence based on metadata availability:
-        - When full metadata is available (_is_default=False): tries squeue,
-          then scontrol, then sacct
-        - When metadata is unavailable (_is_default=True): tries scontrol,
-          then squeue, then sacct
+        - When full metadata is available (_has_full_metadata=True): tries
+          squeue, then scontrol, then sacct
+        - When metadata is unavailable (_has_full_metadata=False): tries
+          scontrol, then squeue, then sacct
 
         This ensures full metadata is obtained on cold start whilst
         optimising for reliability during the polling phase.
@@ -410,7 +409,7 @@ class SSHSlurmTrigger(BaseTrigger):
         """
         has_metadata = (
             self.last_full_state is not None
-            and not self.last_full_state._is_default
+            and self.last_full_state._has_full_metadata
         )
 
         if has_metadata:

--- a/src/airflow_slurm/ssh_slurm_trigger.py
+++ b/src/airflow_slurm/ssh_slurm_trigger.py
@@ -16,6 +16,7 @@
 import asyncio
 import logging
 from collections import Counter
+from dataclasses import dataclass, replace
 from typing import Any, Iterable
 
 import asyncssh
@@ -30,6 +31,29 @@ logger.setLevel(logging.DEBUG)
 
 class JobStateUnavailable(Exception):
     """Raised when job state cannot be determined and retry is needed."""
+
+
+@dataclass
+class JobState:
+    """Represents the state of a SLURM job."""
+
+    job_id: str
+    job_name: str
+    state: str
+    reason: str
+    log_out: str
+    log_err: str
+
+    def dict(self) -> dict[str, str]:
+        """Return serialisation-friendly dictionary representation."""
+        return {
+            "job_id": self.job_id,
+            "job_name": self.job_name,
+            "state": self.state,
+            "reason": self.reason,
+            "log_out": self.log_out,
+            "log_err": self.log_err,
+        }
 
 
 TERMINAL_STATES = {
@@ -78,14 +102,14 @@ class SSHSlurmTrigger(BaseTrigger):
         # FIXME:
         # Initialising with safe-ish values. This should be improved, e.g.,
         # by capturing the output of the job submission call.
-        self.last_full_state = {
-            "job_id": jobid,
-            "job_name": "unknown",
-            "state": "unknown",
-            "reason": "unknown",
-            "log_out": "/dev/null",
-            "log_err": "/dev/null",
-        }
+        self.last_full_state = JobState(
+            job_id=jobid,
+            job_name="unknown",
+            state="unknown",
+            reason="unknown",
+            log_out="/dev/null",
+            log_err="/dev/null",
+        )
         self.last_known_state = last_known_state
         self.last_known_log_lines = last_known_log_lines
         self.tdelta_between_pokes = tdelta_between_pokes
@@ -173,7 +197,7 @@ class SSHSlurmTrigger(BaseTrigger):
                     f"SSH connection failed for command '{command_str}': {e}"
                 )
 
-    async def _get_job_status(self) -> dict | None:
+    async def _get_job_status(self) -> JobState | None:
         """Get SLURM job status using scontrol with sacct fallback.
 
         Attempts to retrieve job status following this flow:
@@ -192,8 +216,8 @@ class SSHSlurmTrigger(BaseTrigger):
            - Returns the actual state (COMPLETED, FAILED, etc.)
 
         Returns:
-            Dictionary containing job information or None if scontrol
-            returned empty output (caller should retry).
+            JobState instance containing job information or None if
+            scontrol returned empty output (caller should retry).
 
         Raises:
             RuntimeError: When job state cannot be determined or is
@@ -225,16 +249,15 @@ class SSHSlurmTrigger(BaseTrigger):
             )
 
             out = records[self.jobid.strip()]
-            out["JobState"] = array_status
-            self.last_full_state = out
-            return {
-                "job_id": out["JobId"],
-                "job_name": out["JobName"],
-                "state": out["JobState"],
-                "reason": out["Reason"],
-                "log_out": out["StdOut"],
-                "log_err": out["StdErr"],
-            }
+            self.last_full_state = JobState(
+                job_id=out["JobId"],
+                job_name=out["JobName"],
+                state=array_status,
+                reason=out["Reason"],
+                log_out=out["StdOut"],
+                log_err=out["StdErr"],
+            )
+            return self.last_full_state
         else:
             logger.warning(
                 "scontrol returned %s with error %s.", exit_code, error
@@ -304,24 +327,7 @@ class SSHSlurmTrigger(BaseTrigger):
                     main_job_exit_code,
                 )
 
-            return {
-                "job_id": self.last_full_state.get(
-                    "JobId", self.last_full_state.get("job_id", self.jobid)
-                ),
-                "job_name": self.last_full_state.get(
-                    "JobName", self.last_full_state.get("job_name", "unknown")
-                ),
-                "state": main_job_state,
-                "reason": self.last_full_state.get(
-                    "Reason", self.last_full_state.get("reason", "unknown")
-                ),
-                "log_out": self.last_full_state.get(
-                    "StdOut", self.last_full_state.get("log_out", "/dev/null")
-                ),
-                "log_err": self.last_full_state.get(
-                    "StdErr", self.last_full_state.get("log_err", "/dev/null")
-                ),
-            }
+            return replace(self.last_full_state, state=main_job_state)
 
     async def parse_scontrol(
         self, scontrol_output: Iterable[str], cancel_pending: bool = True
@@ -434,7 +440,7 @@ class SSHSlurmTrigger(BaseTrigger):
 
     async def get_job_status(
         self, max_retries: int = 3, delay_base_s: int = 3
-    ) -> dict | None:
+    ) -> JobState | None:
         """Get SLURM job status with retry logic for race conditions.
 
         Wraps _get_job_status() with exponential backoff retry logic to
@@ -449,8 +455,8 @@ class SSHSlurmTrigger(BaseTrigger):
                 (delay = base ** (attempt + 1)).
 
         Returns:
-            Dictionary containing job information or None if scontrol
-            returned empty output.
+            JobState instance containing job information or None if
+            scontrol returned empty output.
 
         Raises:
             RuntimeError: When job state cannot be determined after all
@@ -490,26 +496,20 @@ class SSHSlurmTrigger(BaseTrigger):
         while True:
             await asyncio.sleep(self.tdelta_between_pokes)
             slurm_job = await self.get_job_status()
-            slurm_log = await self.get_log(slurm_job.get("log_out", None))
+            slurm_log = await self.get_log(slurm_job.log_out)
 
             self.log.debug(f"{slurm_job=} \n {slurm_log=}")
 
             if slurm_job:
-                # In some cases we do not have the information in the scontrol instantly, we will try again from here
-                # self.tdelta_between_pokes seconds
-
-                slurm_changed_state = (
-                    slurm_job["state"] != self.last_known_state
-                )
-                self.last_known_state = slurm_job["state"]
+                slurm_changed_state = slurm_job.state != self.last_known_state
+                self.last_known_state = slurm_job.state
 
                 if slurm_log or slurm_changed_state:
-                    # We will only send a TriggerEvent when there is a state change or new lines in the log
                     break
 
         yield TriggerEvent(
             {
-                "slurm_job": slurm_job,
+                "slurm_job": slurm_job.dict(),
                 "slurm_changed_state": slurm_changed_state,
                 "log_number_lines": self.last_known_log_lines,
                 "log_new_lines": slurm_log,

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "airflow-slurm"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
# make polling job status more robust

close #23

## Context

Executing sacct locally on the login node of the cluster results in
```bash
sacct -j 32919026
sacct: error: slurm_persist_conn_open_without_init: failed to open persistent connection to host:slurm-slurmdbd.userservices.svc.kube.local:6819: Connection refused
sacct: error: Sending PersistInit msg: Connection refused
sacct: error: Problem talking to the database: Connection refused
```

Trigger traceback follows.

```python
Traceback (most recent call last):

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 150, in _execute_ssh_command
    result = await conn.run(command_str, timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/asyncssh/connection.py", line 4616, in run
    return await process.wait(check, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/asyncssh/process.py", line 1566, in wait
    raise TimeoutError(self.env, self.command, self.subsystem,

asyncssh.process.TimeoutError


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 1005, in cleanup_finished_triggers
    result = details["task"].result()
             ^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 119, in greenback_shim
    return await _greenback_shim(orig_coro, next_send)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 208, in _greenback_shim
    next_yield, resume_greenlet = resume_greenlet.switch(next_send)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/greenback/_impl.py", line 84, in trampoline
    next_yield: Any = next_send.send(orig_coro)  # type: ignore
                      ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/outcome/_impl.py", line 185, in send
    return gen.send(self.value)
           ^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/triggerer_job_runner.py", line 1119, in run_trigger
    async for event in trigger.run():

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 492, in run
    slurm_job = await self.get_job_status()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 461, in get_job_status
    slurm_job = await self._get_job_status()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 244, in _get_job_status
    exit_code, stdout, stderr = await self._execute_ssh_command(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/airflow/.local/lib/python3.12/site-packages/airflow_slurm/ssh_slurm_trigger.py", line 167, in _execute_ssh_command
    raise AirflowException(

airflow.exceptions.AirflowException: SSH command 'sacct -P --format=JobID,State,ExitCode --noheader -j 32919026' timed out after 10 seconds and 5 retry attempts
```

In the meantime, `squeue` is still providing readable output:
```bash
squeue -u jnespolo
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
          32919026 dcgp_usr_ MITgcm+B jnespolo  R    1:11:36      9 lrdn[4058,4061-4062,4066-4067,4077-4080]
```

### Additional context

Current implementation (`ssh_slurm_trigger.py:176-324`): `scontrol` (active
jobs) → `sacct` (completed jobs). When `scontrol` returns empty and `sacct`
times out due to database unavailability, `_execute_ssh_command` raises
`AirflowException` after 5 retries, causing trigger failure. However, `squeue`
remains functional during database outages.

Design decision: Use adaptive fallback sequence based on metadata availability.
After cold start when full job metadata (log paths, job name) is obtained,
prefer `squeue` for its reliability and performance during the long polling
phase. Sequence:

- Has metadata: `squeue` → `scontrol` → `sacct`
- No metadata: `scontrol` → `squeue` → `sacct`

This ensures we get full metadata on cold start, then optimise for the common
case (polling running jobs) whilst maintaining resilience during database
outages. When `sacct` fails, raise `JobStateUnavailable` to trigger existing
retry logic (`get_job_status:435-480`) rather than failing immediately.

## Plan

### Step 0: Create JobState dataclass

- [x] Define a dataclass to represent job state with consistent attributes
  (`job_id`, `job_name`, `state`, `reason`, `log_out`, `log_err`)
- [x] Replace `last_full_state` dict with typed JobState instance
- [x] Update `parse_scontrol` to return JobState objects with lowercase
  attribute names
- [x] Update all code that reads/writes `last_full_state` to use the
  dataclass attributes

### Step 1: Add squeue parser and enhance JobState with metadata tracking

- [x] Update JobState dataclass to include default values for all fields
  (e.g., "unknown" for strings, "/dev/null" for log paths)
- [x] Add private attribute `_is_default: bool = True` to JobState to
  track whether full metadata has been obtained
- [x] Update scontrol parser to set `_is_default=False` when creating
  JobState from scontrol output (which provides full metadata)
- [x] Add `_parse_squeue_output()` method to parse `squeue -j <jobid> -o
  "%i|%T"` output (pipe-delimited JobID|State format) and return a
  JobState object with minimal metadata
- [x] Add `_try_squeue()` helper method that executes `squeue`, parses
  output, and returns a JobState object by merging squeue state with
  cached metadata from `last_full_state` using `dataclasses.replace()`,
  preserving the `_is_default` flag

### Step 2: Refactor `_get_job_status()` with adaptive fallback sequence

- [x] Modify `_get_job_status()` to determine fallback sequence based on
  `last_full_state._is_default`:
  - If `_is_default=False` (metadata available): try squeue, then
    scontrol, then sacct
  - If `_is_default=True` (metadata unavailable): try scontrol, then
    squeue, then sacct
- [x] Wrap sacct execution in try-except to catch `AirflowException` and
  raise `JobStateUnavailable` instead
- [x] Ensure each fallback method (squeue, scontrol, sacct) returns
  `JobState | None` to trigger next fallback
- [x] Preserve existing scontrol and sacct logic (both already return
  JobState objects)

## Implementation log

### Step 0: Create JobState dataclass

Replaced dict-based `last_full_state` with typed `JobState` dataclass. Used
`dataclasses.replace()` for immutable updates in sacct fallback path.
Methods `_get_job_status()` and `get_job_status()` now return `JobState |
None`. Conversion to dict via `.dict()` only occurs at serialisation
boundary (TriggerEvent).

### Step 1: Add squeue parser and enhance JobState with metadata tracking

Added `_has_full_metadata` flag to track metadata completeness. The flag is
False for squeue results (minimal metadata) and set True by scontrol (full
metadata). `_try_squeue()` merges squeue state updates with cached
`last_full_state` via `dataclasses.replace()`, preserving the
`_has_full_metadata` flag from the cached state. This allows Step 2 to
implement adaptive fallback sequences based on metadata availability.

### Step 2: Refactor `_get_job_status()` with adaptive fallback sequence

Extracted scontrol and sacct logic into separate helper methods
`_try_scontrol()` and `_try_sacct()`. Each method returns `JobState |
None`, with None triggering the next fallback method. The main
`_get_job_status()` now implements adaptive fallback sequences: when full
metadata is available (`_has_full_metadata=True`), it tries squeue →
scontrol → sacct (optimising for reliability); when metadata is unavailable
(`_has_full_metadata=False`), it tries scontrol → squeue → sacct
(prioritising full metadata acquisition). Wrapped sacct execution in
try-except to raise `JobStateUnavailable` rather than `AirflowException`,
allowing existing retry logic in `get_job_status()` to handle transient
database outages.

### Post-implementation refinements

Improved code clarity and error reporting:
- Renamed `_is_default` to `_has_full_metadata` for clearer semantics (False
  indicates minimal metadata, True indicates full metadata from scontrol)
- Enhanced error context in `_try_sacct()` by including stderr in
  JobStateUnavailable exception messages for better debugging
- Removed explicit timeout parameter from squeue call to use default value
- Fixed British spelling consistency throughout docstrings