### PR TITLE
fix crash when logical_date and execution_date are both missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airflow-slurm"
-version = "0.2.4"
+version = "0.2.5"
 description = "Airflow operator for slurm"
 readme = "README.md"
 include = ["src/airflow_slurm/py.typed"]

--- a/src/airflow_slurm/ssh_slurm_operator.py
+++ b/src/airflow_slurm/ssh_slurm_operator.py
@@ -163,6 +163,7 @@ class SSHSlurmOperator(BaseOperator):
         Returns:
             Rendered SLURM script as a string.
         """
+        # Mangle job name with a unique identifier
         job_uid = str(uuid.uuid4())[:8]
         self.slurm_options["JOB_NAME"] = (
             f"{self.slurm_options.get('JOB_NAME', 'airflow_slurm_job')}_{job_uid}"

--- a/src/airflow_slurm/ssh_slurm_operator.py
+++ b/src/airflow_slurm/ssh_slurm_operator.py
@@ -14,6 +14,7 @@
 # Modified by Andrea Recchia, 2024
 # Licence: GPLv3
 import subprocess  # nosec
+import uuid
 from typing import Any, Sequence
 
 from airflow.exceptions import AirflowException, AirflowSkipException
@@ -162,13 +163,9 @@ class SSHSlurmOperator(BaseOperator):
         Returns:
             Rendered SLURM script as a string.
         """
-        # Mangle job name with submission date
-        logical_date = context.get("logical_date") or context.get(
-            "execution_date"
-        )
-        job_date = logical_date.strftime("%Y%m%dT%H%M")
+        job_uid = str(uuid.uuid4())[:8]
         self.slurm_options["JOB_NAME"] = (
-            f"{self.slurm_options.get('JOB_NAME', 'airflow_slurm_job')}_{job_date}"
+            f"{self.slurm_options.get('JOB_NAME', 'airflow_slurm_job')}_{job_uid}"
         )
 
         # Process slurm options

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "airflow-slurm"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
Closes #25 

## Summary

- Fix `AttributeError` crash in `parse_input_and_render_slurm_script` when both `logical_date` and `execution_date` are missing from the Airflow context
- Replace date-based job name suffix with a UUID fragment, making the job naming independent of context dates entirely